### PR TITLE
Clean up PostCSS config

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint",
     "check-deps": "node scripts/check-circular-deps.js"
   },
+  "postcss": "postcss.config.js",
   "dependencies": {
     "@ai-sdk/deepinfra": "^0.2.15",
     "@ai-sdk/groq": "^0.0.1",

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,8 +1,0 @@
-/** @type {import('postcss-load-config').Config} */
-const config = {
-  plugins: {
-    tailwindcss: {},
-  },
-};
-
-export default config;


### PR DESCRIPTION
## Summary
- drop unused ESM PostCSS config
- add `postcss` field in `package.json` to reference the CommonJS config

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a4b1c1954832680d3708fc7b22e92